### PR TITLE
Enhance ee_getStr/putStr

### DIFF
--- a/Learn/Simple Libraries/Utility/libsimpletools/source/eeprom_getStr.c
+++ b/Learn/Simple Libraries/Utility/libsimpletools/source/eeprom_getStr.c
@@ -26,8 +26,19 @@ unsigned char* ee_get_str(unsigned char *s, int n, int addr)
   if(!st_eeInitFlag) ee_init();
   // const unsigned char addrArray[] = {(char)(addr >> 8), (char)(addr&0xFF)};
   // i2c_in(st_eeprom, 0xA0, addrArray, 2, s, n);
-  i2c_in(st_eeprom, 0x50, addr, 2, s, n);
-  return s;
+  if(n != 0) {
+    i2c_in(st_eeprom, 0x50, addr, 2, s, n);
+  } else {
+    int i;
+    while(i < 128) {
+      char b[1];
+      i2c_in(st_eeprom, 0x50, addr + i, 2, b, 1);
+      s[i] = b[0];
+      if(b[0] == 0) break;
+      i++;
+    }
+    if(i >= 128) s[127] = 0;
+  }  return s;
 }
 
 /**

--- a/Learn/Simple Libraries/Utility/libsimpletools/source/eeprom_putStr.c
+++ b/Learn/Simple Libraries/Utility/libsimpletools/source/eeprom_putStr.c
@@ -27,11 +27,12 @@ void ee_putStr(unsigned char *s, int n, int addr)
   //unsigned char addrArray[2];
   if(!st_eeInitFlag) ee_init();
 
+  if(n == 0) n = strlen(s) + 1;
+
   while(n > 0)
   {
     //addrArray[0] = (char)(addr >> 8);
     //addrArray[1] = (char)(addr&0xFF);
-
     int pageAddr = addr % 128;
     int byteCnt = 128 - pageAddr;
     if(byteCnt > n) byteCnt = n;


### PR DESCRIPTION
Allow user to set the str length to zero - and have the function auto-detect the string length using the null terminator.  The string, including the null terminator is written to and retrieved from EEPROM.
