### PR TITLE
Fix typo in SimpleIDE project file

### DIFF
--- a/Learn/Simple Libraries/Sensor/liblsm9ds1/liblsm9ds1.side
+++ b/Learn/Simple Libraries/Sensor/liblsm9ds1/liblsm9ds1.side
@@ -4,7 +4,7 @@ imu_init.c
 imu_calibrateAG.c
 imu_calibrateMag.c
 imu_accelAvailable.c
-imu_gryoAvailable.c
+imu_gyroAvailable.c
 imu_SPIread.c
 imu_SPIwrite.c
 imu_getScale.c


### PR DESCRIPTION
Upon updating PropWare to the latest version of Simple, I noticed that it was complaining about this file missing. Not sure if this was really broken, or maybe if that file should just be removed? Anyway, thought I would at least bring it to your attention.